### PR TITLE
Temporarily disable sorting method

### DIFF
--- a/src/browser_refresh/browser_refresh.py
+++ b/src/browser_refresh/browser_refresh.py
@@ -47,8 +47,10 @@ def refreshView(self):
     self.onSearchActivated()
     if SORTING_COLUMN:
         try:
-            col_index = self.model.activeCols.index(SORTING_COLUMN)
-            self.onSortChanged(col_index, True)
+            # TODO: Figure out new method to sort rows?
+            #col_index = self.model.activeCols.index(SORTING_COLUMN)
+            #self.onSortChanged(col_index, True)
+            # For now, just refresh the browser view as the user has it.
             self.form.tableView.selectRow(0)
         except ValueError:
             pass


### PR DESCRIPTION
Remove sorting method that's failing, but still refresh the browser as is.

I tried to figure out how to do that but I don't python and even a simple `print()` is a pain. I also can't find documentation online on how to do this.

`Browser.form.tableView.selectRow(0)` still works and it refreshes the browser which is all I wanted from the add-on anyway.

Thanks!

The [problem line](https://github.com/Arthur-Milchior/anki-addons-misc/blob/refreshBrowser/src/browser_refresh/browser_refresh.py#L50).
```py
Anki 24.04 (bfaa28fe)  (ao)
Python 3.9.18 Qt 6.6.2 PyQt 6.6.1
Platform: Windows-10-10.0.22631

Traceback (most recent call last):
  File "C:\Users\me\AppData\Roaming\Anki2\addons21\1347728560\browser_refresh.py", line 50, in refreshView
    col_index = self.model.activeCols.index(SORTING_COLUMN)
AttributeError: 'MockModel' object has no attribute 'activeCols'
```